### PR TITLE
feat(public): add ^8BALL Magic 8-Ball command (broadcast-only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,7 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "meshbbs"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "anyhow",
  "argon2",

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Welcome to the comprehensive documentation for meshbbs, a modern Bulletin Board 
 ### User Guide
 - [Connecting to the BBS](user-guide/connecting.md) - How to connect via Meshtastic
 - [Command Reference](user-guide/commands.md) - Complete command documentation
-- [Games](user-guide/games.md) - Public channel mini‑games like the Slot Machine
+- [Games](user-guide/games.md) - Public channel mini‑games like Slot Machine and Magic 8‑Ball
 - [Message Topics](user-guide/message-topics.md) - Using the bulletin board system
 - [Troubleshooting](user-guide/troubleshooting.md) - Common issues and solutions
 

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -2,7 +2,7 @@
 
 Complete reference for all meshbbs commands available to users.
 
-See also: the [Games](./games.md) page for public channel mini‑games (e.g., Slot Machine).
+See also: the [Games](./games.md) page for public channel mini‑games (e.g., Slot Machine, Magic 8‑Ball).
 
 ## Connection Commands
 
@@ -21,6 +21,7 @@ Reliability:
 | `^WEATHER` | Show current weather | `^WEATHER` |
 | `^SLOT` / `^SLOTMACHINE` | Spin the emoji slot machine (5 coins per spin; daily refill) | `^SLOT` |
 | `^SLOTSTATS` | Show your coin balance and slot stats | `^SLOTSTATS` |
+| `^8BALL` | Ask the Magic 8‑Ball a question; get a random response | `^8BALL` |
 
 ## Session Commands (Direct Message)
 

--- a/docs/user-guide/games.md
+++ b/docs/user-guide/games.md
@@ -5,7 +5,7 @@ Meshbbs includes optional, lightweight games you can access from the public chan
 ## 🎰 Slot Machine (public channel)
 
 - Commands:
-  - `^SLOT` / `^SLOTMACHINE` — spin once; you always receive a DM with your result, and the BBS also attempts a public broadcast for room visibility
+  - `^SLOT` / `^SLOTMACHINE` — spin once; the BBS broadcasts the result on the public channel (best‑effort)
   - `^SLOTSTATS` — show your coins, spins, wins, and jackpots
 - Economy:
   - Each spin costs 5 coins
@@ -15,11 +15,23 @@ Meshbbs includes optional, lightweight games you can access from the public chan
   - 7️⃣7️⃣7️⃣ = JACKPOT (progressive pot, minimum 500 coins; grows by 5 coins per losing spin), 🟦🟦🟦 ×50, 🔔🔔🔔 ×20, 🍇🍇🍇 ×14, 🍊🍊🍊 ×10, 🍋🍋🍋 ×8, 🍒🍒🍒 ×5
   - Two 🍒 ×3, one 🍒 ×2, otherwise ×0
 - Visibility and reliability:
-  - Your result is always sent via DM (reliable with ACK/retries)
-  - A best-effort public broadcast is also attempted; broadcasts may request an ACK and are considered successful when at least one ACK is received within a short window (no retries)
+  - Results are broadcast to the public channel for room visibility (best‑effort)
+  - Broadcasts may request an ACK and are considered successful when at least one ACK is received within a short window (no retries)
 - Persistence: Player balances and stats are stored under `data/slotmachine/players.json`
 
 Tip: If you see “Out of coins… Next refill in ~Hh Mm”, check back later or run `^SLOTSTATS` to see your current balance and stats.
+
+---
+
+## 🎱 Magic 8‑Ball (public channel)
+
+- Command:
+  - `^8BALL` — ask a yes/no question and receive a classic Magic 8‑Ball response
+- Behavior:
+  - Stateless and lightweight; no persistence
+  - Broadcast-only on the public channel (best‑effort)
+- Reliability:
+  - Broadcasts may request an ACK and are considered successful when at least one ACK is received within a short window (no retries)
 
 ---
 

--- a/src/bbs/eightball.rs
+++ b/src/bbs/eightball.rs
@@ -10,28 +10,28 @@ use rand::Rng;
 /// Classic 20 Magic 8-Ball responses.
 const RESPONSES: [&str; 20] = [
     // Positive
-    "It is certain.",
-    "It is decidedly so.",
-    "Without a doubt.",
-    "Yes — definitely.",
-    "You may rely on it.",
-    "As I see it, yes.",
-    "Most likely.",
-    "Outlook good.",
-    "Yes.",
-    "Signs point to yes.",
+    "✅ It is certain.",
+    "✅ It is decidedly so.",
+    "✅ Without a doubt.",
+    "✅ Yes — definitely.",
+    "✅ You may rely on it.",
+    "👍 As I see it, yes.",
+    "👍 Most likely.",
+    "👍 Outlook good.",
+    "👍 Yes.",
+    "👍 Signs point to yes.",
     // Neutral
-    "Reply hazy, try again.",
-    "Ask again later.",
-    "Better not tell you now.",
-    "Cannot predict now.",
-    "Concentrate and ask again.",
+    "🔮 Reply hazy, try again.",
+    "⏳ Ask again later.",
+    "🤫 Better not tell you now.",
+    "🔮 Cannot predict now.",
+    "🧘 Concentrate and ask again.",
     // Negative
-    "Don't count on it.",
-    "My reply is no.",
-    "My sources say no.",
-    "Outlook not so good.",
-    "Very doubtful.",
+    "❌ Don't count on it.",
+    "❌ My reply is no.",
+    "🚫 My sources say no.",
+    "👎 Outlook not so good.",
+    "👎 Very doubtful.",
 ];
 
 /// Pick a random Magic 8-Ball response.

--- a/src/bbs/eightball.rs
+++ b/src/bbs/eightball.rs
@@ -1,0 +1,58 @@
+//! Magic 8-Ball mini-feature used by public channel command ^8BALL.
+//!
+//! Behavior:
+//! - Stateless: no persistence; just returns a random classic response
+//! - Delivery: public broadcast only (best-effort), same reliability posture as ^SLOT
+//! - Rate limit: handled by PublicState.allow_8ball (light per-node cooldown like ^SLOT)
+
+use rand::Rng;
+
+/// Classic 20 Magic 8-Ball responses.
+const RESPONSES: [&str; 20] = [
+    // Positive
+    "It is certain.",
+    "It is decidedly so.",
+    "Without a doubt.",
+    "Yes — definitely.",
+    "You may rely on it.",
+    "As I see it, yes.",
+    "Most likely.",
+    "Outlook good.",
+    "Yes.",
+    "Signs point to yes.",
+    // Neutral
+    "Reply hazy, try again.",
+    "Ask again later.",
+    "Better not tell you now.",
+    "Cannot predict now.",
+    "Concentrate and ask again.",
+    // Negative
+    "Don't count on it.",
+    "My reply is no.",
+    "My sources say no.",
+    "Outlook not so good.",
+    "Very doubtful.",
+];
+
+/// Pick a random Magic 8-Ball response.
+pub fn ask() -> &'static str {
+    let mut rng = rand::thread_rng();
+    let idx = rng.gen_range(0..RESPONSES.len());
+    RESPONSES[idx]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn responses_count_20() {
+        assert_eq!(super::RESPONSES.len(), 20);
+    }
+
+    #[test]
+    fn ask_returns_known_response() {
+        let resp = ask();
+        assert!(super::RESPONSES.contains(&resp));
+    }
+}

--- a/src/bbs/mod.rs
+++ b/src/bbs/mod.rs
@@ -70,6 +70,7 @@ pub mod public;
 pub mod roles;
 pub mod dispatch;
 pub mod slotmachine;
+pub mod eightball;
 
 pub use server::BbsServer;
 

--- a/src/bbs/server.rs
+++ b/src/bbs/server.rs
@@ -127,7 +127,7 @@ const VERBOSE_HELP: &str = concat!(
     "Sysop (level 10):\n  G @user=LEVEL|ROLE      Grant level (1/5/10) or USER/MOD/SYSOP\n\n",
     "Administration (mod/sysop):\n  USERS [pattern]         List users (filter optional)\n  WHO                     Show logged-in users\n  USERINFO <user>         Detailed user info\n  SESSIONS                List all sessions\n  KICK <user>             Force logout user\n  BROADCAST <msg>         Broadcast to all\n  ADMIN / DASHBOARD       System overview\n\n",
     "Legacy commands (compat):\n  TOPICS / LIST           List topics\n  READ <topic>            Read recent messages\n  POST <topic> <text>     Post a message\n\n",
-    "Misc:\n  HELP        Compact help\n  HELP+ / HELP V  Verbose help (this)\n  Weather (public)  Send WEATHER on public channel\n  Slot Machine (public)  ^SLOT or ^SLOTMACHINE to play\n  Slot Stats (public)    ^SLOTSTATS\n\n",
+    "Misc:\n  HELP        Compact help\n  HELP+ / HELP V  Verbose help (this)\n  Weather (public)       Send WEATHER on public channel\n  Slot Machine (public)  ^SLOT or ^SLOTMACHINE to play\n  Slot Stats (public)    ^SLOTSTATS\n  Magic 8-Ball (public)  ^8BALL\n\n",
     "Limits:\n  Max frame ~230 bytes; verbose help auto-splits.\n"
 );
 
@@ -1601,6 +1601,17 @@ impl BbsServer {
                         #[cfg(feature = "meshtastic-proto")]
                         {
                             if let Err(e) = self.send_broadcast(&msg).await { warn!("Slot result broadcast failed (best-effort): {e:?}"); }
+                        }
+                    }
+                }
+                PublicCommand::EightBall => {
+                    // Lightweight per-node cooldown similar to ^SLOT; broadcast-only.
+                    if self.public_state.allow_8ball(&node_key) {
+                        let answer = crate::bbs::eightball::ask();
+                        let msg = format!("^8BALL ⟶ {}", answer);
+                        #[cfg(feature = "meshtastic-proto")]
+                        {
+                            if let Err(e) = self.send_broadcast(&msg).await { warn!("8BALL broadcast failed (best-effort): {e:?}"); }
                         }
                     }
                 }

--- a/tests/eightball_behavior.rs
+++ b/tests/eightball_behavior.rs
@@ -1,0 +1,47 @@
+#![cfg(feature = "meshtastic-proto")]
+use meshbbs::bbs::BbsServer;
+mod common;
+use meshbbs::config::Config;
+
+#[tokio::test]
+async fn eightball_broadcasts_and_not_dm() {
+    let mut config = Config::default();
+    config.storage.data_dir = crate::common::fixture_root().to_string_lossy().to_string();
+    // Keep public cooldowns small for tests (defaults are already small)
+    let mut server = BbsServer::new(config).await.expect("server");
+
+    use meshbbs::meshtastic::TextEvent;
+    let node_id = 4242u32;
+    let public_evt = TextEvent { source: node_id, dest: None, is_direct: false, channel: None, content: "^8BALL".into() };
+    server.route_text_event(public_evt).await.expect("route public 8ball");
+
+    // Inspect recorded outbound messages
+    let msgs = server.test_messages();
+    assert!(msgs.iter().any(|(to, body)| to == "BCAST" && body.starts_with("^8BALL ⟶ ")), "expected ^8BALL broadcast in test_messages, got {:?}", msgs);
+    // Ensure no DM was sent to the origin node
+    assert!(!msgs.iter().any(|(to, _)| to == &node_id.to_string()), "did not expect DM to {}", node_id);
+}
+
+#[tokio::test]
+async fn eightball_respects_cooldown() {
+    let mut config = Config::default();
+    config.storage.data_dir = crate::common::fixture_root().to_string_lossy().to_string();
+    let mut server = BbsServer::new(config).await.expect("server");
+
+    use meshbbs::meshtastic::TextEvent;
+    let node_id = 777u32;
+    let evt1 = TextEvent { source: node_id, dest: None, is_direct: false, channel: None, content: "^8BALL".into() };
+    let evt2 = TextEvent { source: node_id, dest: None, is_direct: false, channel: None, content: "^8BALL".into() };
+    server.route_text_event(evt1).await.expect("first 8ball");
+    server.route_text_event(evt2).await.expect("second 8ball (cooldown)");
+
+    // Only one broadcast should have been queued due to per-node cooldown
+    let bcasts: Vec<_> = server.test_messages().iter().filter(|(to, body)| to == "BCAST" && body.starts_with("^8BALL ⟶ ")).collect();
+    assert_eq!(bcasts.len(), 1, "expected only one broadcast due to cooldown, got {:?}", server.test_messages());
+}
+
+#[cfg(not(feature = "meshtastic-proto"))]
+#[test]
+fn eightball_behavior_skipped() {
+    eprintln!("eightball_behavior skipped: meshtastic-proto feature disabled");
+}

--- a/tests/public_8ball.rs
+++ b/tests/public_8ball.rs
@@ -1,0 +1,8 @@
+use meshbbs::bbs::public::{PublicCommandParser, PublicCommand};
+
+#[test]
+fn parse_8ball_command() {
+    let parser = PublicCommandParser::new();
+    match parser.parse("^8ball") { PublicCommand::EightBall => {}, other => panic!("Expected EightBall, got {:?}", other) }
+    match parser.parse("^8BALL") { PublicCommand::EightBall => {}, other => panic!("Expected EightBall uppercase, got {:?}", other) }
+}

--- a/tests/test-data-int/users/alice.json
+++ b/tests/test-data-int/users/alice.json
@@ -3,7 +3,7 @@
   "node_id": "123",
   "access_level": 1,
   "first_login": "2025-01-01T00:00:00Z",
-  "last_login": "2025-09-26T22:12:58.499269Z",
+  "last_login": "2025-09-26T22:15:58.834386Z",
   "total_messages": 0,
   "welcome_shown_on_registration": false,
   "welcome_shown_on_first_login": false

--- a/tests/test-data-int/users/alice.json
+++ b/tests/test-data-int/users/alice.json
@@ -3,7 +3,7 @@
   "node_id": "123",
   "access_level": 1,
   "first_login": "2025-01-01T00:00:00Z",
-  "last_login": "2025-09-26T21:51:36.867151Z",
+  "last_login": "2025-09-26T22:12:58.499269Z",
   "total_messages": 0,
   "welcome_shown_on_registration": false,
   "welcome_shown_on_first_login": false

--- a/tests/test-data-int/users/alice.json
+++ b/tests/test-data-int/users/alice.json
@@ -3,7 +3,7 @@
   "node_id": "123",
   "access_level": 1,
   "first_login": "2025-01-01T00:00:00Z",
-  "last_login": "2025-09-26T21:01:21.587522Z",
+  "last_login": "2025-09-26T21:45:59.038850Z",
   "total_messages": 0,
   "welcome_shown_on_registration": false,
   "welcome_shown_on_first_login": false

--- a/tests/test-data-int/users/alice.json
+++ b/tests/test-data-int/users/alice.json
@@ -3,7 +3,7 @@
   "node_id": "123",
   "access_level": 1,
   "first_login": "2025-01-01T00:00:00Z",
-  "last_login": "2025-09-26T21:45:59.038850Z",
+  "last_login": "2025-09-26T21:51:36.867151Z",
   "total_messages": 0,
   "welcome_shown_on_registration": false,
   "welcome_shown_on_first_login": false

--- a/tests/test-data-int/users/carol.json
+++ b/tests/test-data-int/users/carol.json
@@ -3,7 +3,7 @@
   "node_id": "300",
   "access_level": 1,
   "first_login": "2025-01-01T00:00:00Z",
-  "last_login": "2025-09-26T21:01:17.583390Z",
+  "last_login": "2025-09-26T21:51:33.705548Z",
   "total_messages": 0,
   "welcome_shown_on_registration": false,
   "welcome_shown_on_first_login": false

--- a/tests/test-data-int/users/carol.json
+++ b/tests/test-data-int/users/carol.json
@@ -3,7 +3,7 @@
   "node_id": "300",
   "access_level": 1,
   "first_login": "2025-01-01T00:00:00Z",
-  "last_login": "2025-09-26T22:12:57.613095Z",
+  "last_login": "2025-09-26T22:15:54.111611Z",
   "total_messages": 0,
   "welcome_shown_on_registration": false,
   "welcome_shown_on_first_login": false

--- a/tests/test-data-int/users/carol.json
+++ b/tests/test-data-int/users/carol.json
@@ -3,7 +3,7 @@
   "node_id": "300",
   "access_level": 1,
   "first_login": "2025-01-01T00:00:00Z",
-  "last_login": "2025-09-26T21:51:33.705548Z",
+  "last_login": "2025-09-26T22:12:57.613095Z",
   "total_messages": 0,
   "welcome_shown_on_registration": false,
   "welcome_shown_on_first_login": false


### PR DESCRIPTION
This PR adds a new public command: ^8BALL (Magic 8-Ball).

Summary
- New module src/bbs/eightball.rs with 20 classic Magic 8-Ball responses (emoji-prefixed) and ask() selector
- Public parser recognizes ^8BALL and routes to a broadcast-only handler
- Per-node lightweight cooldown matching ^SLOT behavior to prevent spam
- Reliability semantics identical to ^SLOT: broadcast-only, best-effort delivery (no DM fallback, no retries); optional want_ack treated as “at least one ack” if requested by scheduler
- Verbose public HELP updated to list ^8BALL
- Documentation updated: docs/user-guide/commands.md and docs/user-guide/games.md to describe the new command and clarify slot machine delivery semantics

Files touched (high level)
- src/bbs/eightball.rs (new) – responses + ask()
- src/bbs/mod.rs – export module
- src/bbs/public.rs – add PublicCommand::EightBall + parser + cooldown state/allowance
- src/bbs/server.rs – ^8BALL handler: broadcast-only; HELP entries
- tests/public_8ball.rs – parser recognition tests
- tests/eightball_behavior.rs – behavior tests for broadcast-only and cooldown
- docs/user-guide/commands.md, docs/user-guide/games.md, docs/README.md – docs additions/clarifications

Behavior
- Command: ^8BALL entered in Public channel
- Response: a single broadcast message in Public, formatted like: “^8BALL ⟶ <emoji> <response>”
- Cooldown: per-node short cooldown to avoid back-to-back spam, aligned with ^SLOT’s model
- No DM fallback (by design); matches the slot machine user experience

Testing
- Unit tests: eightball module (response count and membership)
- Parser test: ^8BALL recognized (case-insensitive)
- Integration/behavior tests: broadcast-only behavior; cooldown respected
- Full cargo test suite passes locally; release build succeeds

Notes
- Per request, top-level README.md and CHANGELOG.md were not updated; those can be handled during PR merge
- No changes to existing slot machine functionality; only clarified docs to explicitly say broadcast-only

Screenshots/Docs
- See docs/user-guide/games.md for Magic 8-Ball section and delivery notes

Requesting review for:
- Command UX and response phrasing/emoji choices
- Cooldown duration alignment with ^SLOT
- Help/docs wording
